### PR TITLE
LRDOCS-9396 adds dev tutorial code for Creating Custom Video Shortcut Provider

### DIFF
--- a/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/creating-custom-video-shortcut-providers/resources/liferay-g9b6.zip/g9b6-impl/bnd.bnd
+++ b/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/creating-custom-video-shortcut-providers/resources/liferay-g9b6.zip/g9b6-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme G9B6 Implementation
+Bundle-SymbolicName: com.acme.G9B6.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/creating-custom-video-shortcut-providers/resources/liferay-g9b6.zip/g9b6-impl/build.gradle
+++ b/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/creating-custom-video-shortcut-providers/resources/liferay-g9b6.zip/g9b6-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/creating-custom-video-shortcut-providers/resources/liferay-g9b6.zip/g9b6-impl/src/main/java/com/acme/g9b6/document/library/internal/video/external/shortcut/provider/G9B6DLVideoExternalShortcutProvider.java
+++ b/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/creating-custom-video-shortcut-providers/resources/liferay-g9b6.zip/g9b6-impl/src/main/java/com/acme/g9b6/document/library/internal/video/external/shortcut/provider/G9B6DLVideoExternalShortcutProvider.java
@@ -1,0 +1,57 @@
+package com.acme.g9b6.document.library.internal.video.external.shortcut.provider;
+
+import com.liferay.document.library.video.external.shortcut.DLVideoExternalShortcut;
+import com.liferay.document.library.video.external.shortcut.provider.DLVideoExternalShortcutProvider;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.Validator;
+import java.net.HttpURLConnection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.servlet.http.HttpServletRequest;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(service = DLVideoExternalShortcutProvider.class)
+public class G9B6DLVideoExternalShortcutProvider
+    implements DLVideoExternalShortcutProvider {
+
+    @Override
+    public DLVideoExternalShortcut getDLVideoExternalShortcut(String url) {
+        String dailymotionVideoId;
+        Pattern urlPattern = Pattern.compile(
+            "https?:\\/\\/(?:www\\.)?dai\\.ly\\/(\\S*)$");
+            Matcher matcher = urlPattern.matcher(url);
+
+        if (matcher.matches()) {
+            dailymotionVideoId = matcher.group(1);
+        } else {
+            dailymotionVideoId = null;
+        }
+
+        if (Validator.isNull(dailymotionVideoId)) {
+            return null;
+        }
+
+        return new DLVideoExternalShortcut() {
+
+            @Override
+            public String getURL() {
+                return url;
+            }
+
+            @Override
+            public String renderHTML(HttpServletRequest httpServletRequest) {
+                String iframeSrc =
+                    "https://www.dailymotion.com/embed/video/" + dailymotionVideoId +
+                        "?rel=0";
+
+                return StringBundler.concat(
+                    "<iframe allow=\"autoplay; encrypted-media\" ",
+                    "allowfullscreen height=\"315\" frameborder=\"0\" ",
+                    "src=\"", iframeSrc, "\" width=\"560\"></iframe>");
+            }
+        };
+    }
+}

--- a/docs/dxp/latest/en/using-search/search-administration-and-tuning/synonym-sets.md
+++ b/docs/dxp/latest/en/using-search/search-administration-and-tuning/synonym-sets.md
@@ -48,7 +48,7 @@ In the example above, this blog article about a lunar rover does not contain the
 
 ## Creating New Synonym Language Filters
 
-> **Availability: Liferay DXP 7.3 FP2+ and Liferay DXP 7.2 FP12+**
+> **Availability: Liferay DXP 7.3 FP2+ and Liferay DXP 7.2 FP13+**
 
 Out of the box, Synonyms Sets supports synonyms in [English and Spanish only](#requirements-and-limitations). To add support for other languages use the configuration steps below:
 


### PR DESCRIPTION
This PR includes dev tutorial code for a new Documents and Media article, _Creating Custom Video Shortcut Providers_. This covers a 7.4 feature, so you'll have to either update the version used for `update_example.sh`, or modify the code sample's `gradle.properties` file to use 7.4 and run gradlew commands from its folder.

The sample implements the [`DLVideoExternalShortcutProvider.java`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/video/external/shortcut/provider/DLVideoExternalShortcutProvider.java) interface, and it can be compared to [`YouTubeDLVideoExternalShortcutProvider`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/video/external/shortcut/provider/YouTubeDLVideoExternalShortcutProvider.java), and [other implementations](https://github.com/liferay/liferay-portal/tree/master/modules/apps/document-library/document-library-video/src/main/java/com/liferay/document/library/video/internal/video/external/shortcut/provider) of this interface.

For a rough draft of the dev article, see [Creating Custom Video Shortcut Providers](https://github.com/JamesAGarcia/liferay-learn/blob/LRDOCS-9396-article/docs/dxp/latest/en/content-authoring-and-management/documents-and-media/developer-guide/creating-custom-video-shortcut-providers.md)