### PR TITLE
LRDOCS-8961 Draft code for direct synchronous message exchange

### DIFF
--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-api/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-api/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme M4Q7 Able API
+Bundle-SymbolicName: com.acme.m4q7.able.api
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-api/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-api/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-api/src/main/java/com/acme/m4q7/able/constants/M4Q7AbleDestinationNames.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-api/src/main/java/com/acme/m4q7/able/constants/M4Q7AbleDestinationNames.java
@@ -1,0 +1,8 @@
+package com.acme.m4q7.able.constants;
+
+public class M4Q7AbleDestinationNames {
+
+	public static final String M4Q7_ABLE_DESTINATION =
+		"acme/m4q7_able_destination";
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme M4Q7 Able Implementation
+Bundle-SymbolicName: com.acme.m4q7.able.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-impl/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly project(":m4q7-able-api")
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-impl/src/main/java/com/acme/m4q7/able/internal/messaging/M4Q7AbleMessagingConfigurator.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-able-impl/src/main/java/com/acme/m4q7/able/internal/messaging/M4Q7AbleMessagingConfigurator.java
@@ -1,0 +1,47 @@
+package com.acme.m4q7.able.internal.messaging;
+
+import com.acme.m4q7.able.constants.M4Q7AbleDestinationNames;
+
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public class M4Q7AbleMessagingConfigurator {
+
+	@Activate
+	private void _activate(BundleContext bundleContext) {
+		DestinationConfiguration destinationConfiguration =
+			DestinationConfiguration.createSynchronousDestinationConfiguration(
+				M4Q7AbleDestinationNames.M4Q7_ABLE_DESTINATION);
+
+		Destination destination = _destinationFactory.createDestination(
+			destinationConfiguration);
+
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
+			MapUtil.singletonDictionary(
+				"destination.name", destination.getName()));
+	}
+
+	@Deactivate
+	private void _deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	private ServiceRegistration<Destination> _serviceRegistration;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-baker-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-baker-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme M4Q7 Baker Implementation
+Bundle-SymbolicName: com.acme.m4q7.baker.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-baker-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-baker-impl/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly project(":m4q7-able-api")
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-baker-impl/src/main/java/com/acme/m4q7/baker/osgi/commands/M4Q7BakerOSGiCommands.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-baker-impl/src/main/java/com/acme/m4q7/baker/osgi/commands/M4Q7BakerOSGiCommands.java
@@ -1,0 +1,94 @@
+package com.acme.m4q7.baker.osgi.commands;
+
+import com.acme.m4q7.able.constants.M4Q7AbleDestinationNames;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBusException;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.messaging.sender.SynchronousMessageSender;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	property = {
+		"destination.name=" + M4Q7BakerOSGiCommands.M4Q7_BAKER_DESTINATION,
+		"osgi.command.function=sendPayload", "osgi.command.scope=m4q7.baker"
+	},
+	service = MessageListener.class
+)
+public class M4Q7BakerOSGiCommands implements MessageListener {
+
+	public static final String M4Q7_BAKER_DESTINATION =
+		"acme/m4q7_baker_destination";
+
+	@Override
+	public void receive(Message message) {
+		if (_log.isInfoEnabled()) {
+			Object payload = message.getPayload();
+
+			_log.info("Received message payload " + payload.toString());
+		}
+	}
+
+	public void sendPayload(String payload) {
+		try {
+			Message message = new Message();
+
+			message.setPayload(payload);
+
+			message.setResponseDestinationName(M4Q7_BAKER_DESTINATION);
+			message.setResponseId("1234");
+
+			_directSynchronousMessageSender.send(
+				M4Q7AbleDestinationNames.M4Q7_ABLE_DESTINATION, message);
+		}
+		catch (MessageBusException messageBusException) {
+			messageBusException.printStackTrace();
+		}
+	}
+
+	@Activate
+	private void _activate(BundleContext bundleContext) {
+		DestinationConfiguration destinationConfiguration =
+			DestinationConfiguration.createSynchronousDestinationConfiguration(
+				M4Q7_BAKER_DESTINATION);
+
+		Destination destination = _destinationFactory.createDestination(
+			destinationConfiguration);
+
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
+			MapUtil.singletonDictionary(
+				"destination.name", destination.getName()));
+	}
+
+	@Deactivate
+	private void _deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		M4Q7BakerOSGiCommands.class);
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	@Reference(target = "(mode=DIRECT)")
+	private SynchronousMessageSender _directSynchronousMessageSender;
+
+	private ServiceRegistration<Destination> _serviceRegistration;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-charlie-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-charlie-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme M4Q7 Charlie Implementation
+Bundle-SymbolicName: com.acme.m4q7.charlie.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-charlie-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-charlie-impl/build.gradle
@@ -1,0 +1,4 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+	compileOnly project(":m4q7-able-api")
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-charlie-impl/src/main/java/com/acme/m4q7/charlie/internal/messaging/M4Q7CharlieMessageListener.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip/m4q7-charlie-impl/src/main/java/com/acme/m4q7/charlie/internal/messaging/M4Q7CharlieMessageListener.java
@@ -1,0 +1,48 @@
+package com.acme.m4q7.charlie.internal.messaging;
+
+import com.acme.m4q7.able.constants.M4Q7AbleDestinationNames;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBusException;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.messaging.sender.SynchronousMessageSender;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	property = "destination.name=" + M4Q7AbleDestinationNames.M4Q7_ABLE_DESTINATION,
+	service = MessageListener.class
+)
+public class M4Q7CharlieMessageListener implements MessageListener {
+
+	@Override
+	public void receive(Message message) {
+		if (_log.isInfoEnabled()) {
+			Object payload = message.getPayload();
+
+			_log.info("Received message payload " + payload.toString());
+
+			try {
+				Message response = new Message();
+
+				response.setPayload("Hello back");
+
+				_directSynchronousMessageSender.send(
+					message.getResponseDestinationName(), response);
+			}
+			catch (MessageBusException messageBusException) {
+				messageBusException.printStackTrace();
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		M4Q7CharlieMessageListener.class);
+
+	@Reference(target = "(mode=DIRECT)")
+	private SynchronousMessageSender _directSynchronousMessageSender;
+
+}


### PR DESCRIPTION
@shuyangzhou Would you please review this example code for message exchange with `DirectSynchronousMessageSender`?

**Running the example:**

1. Start a 7.3+ container
1. Add Workspace to the example project.

    ```bash
    ./update_examples.sh m4q7
    ```
2. Deploy the example.

    ```bash
    cd liferay-learn/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/sending-messages-synchronously/resources/liferay-m4q7.zip
    ```

    ```bash
    ./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
    ```
3. Sign in to DXP/Portal and go to the Gogo Shell console.
4. Execute the following command...

    ```
    sendPayload Hello
    ```

Verify that the console messages look like these:

```
2021-05-25 15:26:19.809 INFO  [pipe-sendPayload Hello][M4Q7CharlieMessageListener:26] Received message payload Hello
2021-05-25 15:26:19.809 INFO  [pipe-sendPayload Hello][M4Q7BakerOSGiCommands:40] Received message payload Hello back
```

**Bundle overview:**

- `m4q7-able-api` defines the name of a public Destination.
- `m4q7-able-impl` configures and registers the Destination.
- `m4q7-baker-impl `sends a message to the public Destination and listens on the message's response Destination.
- `m4q7-charlie-impl` receives

 messages sent to the public Destination and replies with a message to the response Destination.

**Bundle Details:**

1. `m4q7-able-api`'s `M4Q7AbleDestinationNames` class defines Destination name constant `M4Q7_ABLE_DESTINATION`
2. `m4q7-able-impl`'s `M4Q7AbleMessagingConfigurator` registers `M4Q7_ABLE_DESTINATION` as a synchronous destination
3. `m4q7-charlie-impl`'s `M4Q7CharlieMessageListener` listens at `M4Q7_ABLE_DESTINATION`.
4. `m4q7-baker-impl`'s `M4Q7BakerOSGiCommands` configures and registers as a listener for a synchronous response Destination named `M4Q7_BAKER_DESTINATION`. `M4Q7BakerOSGiCommands` sends a message to `M4Q7_ABLE_DESTINATION` with `M4Q7_BAKER_DESTINATION` set as its response destination name.
5. `M4Q7CharlieMessageListener` receives the message, prints the payload, and sends a response message to the response Destination (i.e., `M4Q7_BAKER_DESTINATION`).
6. `M4Q7BakerOSGiCommands` receives the response message and prints its payload.