### PR TITLE
Lrdocs 9512 code for tuning messaging performance

### DIFF
--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme W3R2 Able Implementation
+Bundle-SymbolicName: com.acme.w3r2.able.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/src/main/java/com/acme/w3r2/able/internal/messaging/W3R2AbleMessagingConfigurator.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/src/main/java/com/acme/w3r2/able/internal/messaging/W3R2AbleMessagingConfigurator.java
@@ -1,0 +1,42 @@
+package com.acme.w3r2.able.internal.messaging;
+
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationConfiguration;
+import com.liferay.portal.kernel.messaging.DestinationFactory;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceRegistration;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public class W3R2AbleMessagingConfigurator {
+
+	@Activate
+	private void _activate(BundleContext bundleContext) {
+		Destination destination = _destinationFactory.createDestination(
+			DestinationConfiguration.createParallelDestinationConfiguration(
+				"acme/w3r2_able"));
+
+		_serviceRegistration = bundleContext.registerService(
+			Destination.class, destination,
+			MapUtil.singletonDictionary(
+				"destination.name", destination.getName()));
+	}
+
+	@Deactivate
+	private void _deactivate() {
+		if (_serviceRegistration != null) {
+			_serviceRegistration.unregister();
+		}
+	}
+
+	@Reference
+	private DestinationFactory _destinationFactory;
+
+	private ServiceRegistration<Destination> _serviceRegistration;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/src/main/java/com/acme/w3r2/able/internal/messaging/W3R2AbleMessagingConfigurator.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/src/main/java/com/acme/w3r2/able/internal/messaging/W3R2AbleMessagingConfigurator.java
@@ -1,6 +1,5 @@
 package com.acme.w3r2.able.internal.messaging;
 
-import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Destination;
@@ -28,6 +27,10 @@ public class W3R2AbleMessagingConfigurator {
 		// destinationConfiguration.setWorkersCoreSize(workersCoreSize);
 		// destinationConfiguration.setWorkersMaxSize(workersMaxSize);
 
+		if (_log.isInfoEnabled()) {
+			_log.info(destinationConfiguration.toString());
+		}
+
 		Destination destination = _destinationFactory.createDestination(
 			destinationConfiguration);
 
@@ -35,21 +38,6 @@ public class W3R2AbleMessagingConfigurator {
 			Destination.class, destination,
 			MapUtil.singletonDictionary(
 				"destination.name", destination.getName()));
-
-		if (_log.isInfoEnabled()) {
-			StringBundler sb = new StringBundler(8);
-
-			sb.append("Destination ");
-			sb.append(destination.getName());
-			sb.append(", max queue size ");
-			sb.append(destinationConfiguration.getMaximumQueueSize());
-			sb.append(", worker core size ");
-			sb.append(destinationConfiguration.getWorkersCoreSize());
-			sb.append(", worker max size ");
-			sb.append(destinationConfiguration.getWorkersMaxSize());
-
-			_log.info(sb.toString());
-		}
 	}
 
 	@Deactivate

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/src/main/java/com/acme/w3r2/able/internal/messaging/W3R2AbleMessagingConfigurator.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-able-impl/src/main/java/com/acme/w3r2/able/internal/messaging/W3R2AbleMessagingConfigurator.java
@@ -1,5 +1,8 @@
 package com.acme.w3r2.able.internal.messaging;
 
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.messaging.Destination;
 import com.liferay.portal.kernel.messaging.DestinationConfiguration;
 import com.liferay.portal.kernel.messaging.DestinationFactory;
@@ -17,14 +20,36 @@ public class W3R2AbleMessagingConfigurator {
 
 	@Activate
 	private void _activate(BundleContext bundleContext) {
-		Destination destination = _destinationFactory.createDestination(
+		DestinationConfiguration destinationConfiguration =
 			DestinationConfiguration.createParallelDestinationConfiguration(
-				"acme/w3r2_able"));
+				"acme/w3r2_able");
+
+		// destinationConfiguration.setMaximumQueueSize(maximumQueueSize);
+		// destinationConfiguration.setWorkersCoreSize(workersCoreSize);
+		// destinationConfiguration.setWorkersMaxSize(workersMaxSize);
+
+		Destination destination = _destinationFactory.createDestination(
+			destinationConfiguration);
 
 		_serviceRegistration = bundleContext.registerService(
 			Destination.class, destination,
 			MapUtil.singletonDictionary(
 				"destination.name", destination.getName()));
+
+		if (_log.isInfoEnabled()) {
+			StringBundler sb = new StringBundler(8);
+
+			sb.append("Destination ");
+			sb.append(destination.getName());
+			sb.append(", max queue size ");
+			sb.append(destinationConfiguration.getMaximumQueueSize());
+			sb.append(", worker core size ");
+			sb.append(destinationConfiguration.getWorkersCoreSize());
+			sb.append(", worker max size ");
+			sb.append(destinationConfiguration.getWorkersMaxSize());
+
+			_log.info(sb.toString());
+		}
 	}
 
 	@Deactivate
@@ -33,6 +58,9 @@ public class W3R2AbleMessagingConfigurator {
 			_serviceRegistration.unregister();
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		W3R2AbleMessagingConfigurator.class);
 
 	@Reference
 	private DestinationFactory _destinationFactory;

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme W3R2 Baker Implementation
+Bundle-SymbolicName: com.acme.w3r2.baker.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/src/main/java/com/acme/w3r2/baker/internal/W3R2BakerOSGiCommands.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-baker-impl/src/main/java/com/acme/w3r2/baker/internal/W3R2BakerOSGiCommands.java
@@ -1,0 +1,35 @@
+package com.acme.w3r2.baker.internal;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	property = {"osgi.command.function=sendMessage", "osgi.command.scope=w3r2"},
+	service = W3R2BakerOSGiCommands.class
+)
+public class W3R2BakerOSGiCommands {
+
+	public void sendMessage(String payload) {
+		Message message = new Message();
+
+		message.setPayload(payload);
+
+		_messageBus.sendMessage("acme/w3r2_able", message);
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Sent message payload " + payload);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		W3R2BakerOSGiCommands.class);
+
+	@Reference
+	private MessageBus _messageBus;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme W3R2 Charlie Implementation
+Bundle-SymbolicName: com.acme.w3r2.charlie.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/src/main/java/com/acme/w3r2/charlie/internal/messaging/W3R2CharlieMessageListenerManager.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-charlie-impl/src/main/java/com/acme/w3r2/charlie/internal/messaging/W3R2CharlieMessageListenerManager.java
@@ -1,0 +1,55 @@
+package com.acme.w3r2.charlie.internal.messaging;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageBus;
+import com.liferay.portal.kernel.messaging.MessageListener;
+
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+@Component
+public class W3R2CharlieMessageListenerManager {
+
+	@Activate
+	private void _activate() {
+		for (int i = 0; i < 5; i++) {
+			_messageBus.registerMessageListener(
+				"acme/w3r2_able",
+				new MessageListener() {
+
+					@Override
+					public void receive(Message message) {
+						if (_log.isInfoEnabled()) {
+							Object payload = message.getPayload();
+
+							_log.info(
+								"Received message payload " +
+									payload.toString());
+						}
+					}
+
+				});
+		}
+	}
+
+	@Deactivate
+	private void _deactivate() {
+		Destination destination = _messageBus.getDestination("acme/w3r2_able");
+
+		if (destination != null) {
+			destination.unregisterMessageListeners();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		W3R2CharlieMessageListenerManager.class);
+
+	@Reference
+	private MessageBus _messageBus;
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-easy-impl/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-easy-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme W3R2 Easy Implementation
+Bundle-SymbolicName: com.acme.w3r2.easy.impl
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-easy-impl/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-easy-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-easy-impl/src/main/java/com/acme/w3r2/easy/internal/osgi/commands/W3R2EasyOSGiCommands.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip/w3r2-easy-impl/src/main/java/com/acme/w3r2/easy/internal/osgi/commands/W3R2EasyOSGiCommands.java
@@ -1,0 +1,66 @@
+package com.acme.w3r2.easy.internal.osgi.commands;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.Destination;
+import com.liferay.portal.kernel.messaging.DestinationStatistics;
+import com.liferay.portal.kernel.messaging.MessageBus;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	property = {
+		"osgi.command.function=listDestinationStats", "osgi.command.scope=w3r2"
+	},
+	service = W3R2EasyOSGiCommands.class
+)
+public class W3R2EasyOSGiCommands {
+
+	public void listDestinationStats(String destinationName) {
+		if (_log.isInfoEnabled()) {
+			Destination destination = _messageBus.getDestination(
+				destinationName);
+
+			if (destination == null) {
+				_log.info("Destination not found " + destinationName);
+
+				return;
+			}
+
+			DestinationStatistics destinationStatistics =
+				destination.getDestinationStatistics();
+
+			StringBundler sb = new StringBundler(18);
+
+			sb.append("Destination ");
+			sb.append(destinationName);
+			sb.append(", message listener count ");
+			sb.append(destination.getMessageListenerCount());
+			sb.append(", active thread count ");
+			sb.append(destinationStatistics.getActiveThreadCount());
+			sb.append(", current thread count ");
+			sb.append(destinationStatistics.getCurrentThreadCount());
+			sb.append(", largest thread count ");
+			sb.append(destinationStatistics.getLargestThreadCount());
+			sb.append(", max thread pool size ");
+			sb.append(destinationStatistics.getMaxThreadPoolSize());
+			sb.append(", min thread pool size ");
+			sb.append(destinationStatistics.getMinThreadPoolSize());
+			sb.append(", pending message count ");
+			sb.append(destinationStatistics.getPendingMessageCount());
+			sb.append(", sent message count ");
+			sb.append(destinationStatistics.getSentMessageCount());
+
+			_log.info(sb.toString());
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		W3R2EasyOSGiCommands.class);
+
+	@Reference
+	private MessageBus _messageBus;
+
+}


### PR DESCRIPTION
@shuyangzhou or @tinatian, can you review this example project? Thanks in advance!

Here are the classes:

- `w3r2-able-impl` module's `W3R2AbleMessagingConfigurator` configures the destination and logs the configuration details.
- `w3r2-baker-impl` module's `W3R2BakerOSGiCommands` provides Gogo shell command `w3r2:sendMessage String` to send a message to the destination.
- `w3r2-charlie-impl` module's `W3R2CharlieMessageListenerManager` registers n number of message listeners to the destination.
- `w3r2-easy-impl` module's `W3R2EasyOSGiCommands` provides Gogo shell command `w3r2:listDestinationStats acme/w3r2_able` to log the destination's stats for monitoring.

All of the classes log their activities. 

Here are steps for using the project:
1. `cd liferay-learn/docs`
2. Add Workshop to the project: `./update_examples w3r2`
3. Go to the project folder:
    ```bash
    cd dxp/latest/en/developing-applications/core-frameworks/message-bus/tuning-messaging-performance/resources/liferay-w3r2.zip
    ```
4. Deploy the project's modules: `./gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)`
5. In Gogo shell, use the `w3r2:sendMessage String` to send messages and `w3r2:listDestinationStats acme/w3r2_able` to get destination stats. Check the console log.
6. Adjust destination settings by uncommenting setters in `W3R2AbleMessagingConfigurator`, setting new values, and redeploying the `w3r2-able-impl` module.
    ```bash
    cd w3r2-able-impl; ../gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
    ```
7. Adjust the number of message senders generated in W3R2CharlieMessageListenerManager#_activate() for loop limit and redploy the `w3r2-charlie-impl` module. 
    ```bash
    cd ../w3r2-charlie-impl; ../gradlew deploy -Ddeploy.docker.container.id=$(docker ps -lq)
    ```