### PR TITLE
LRDOCS-9544 Portlet Level Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,4 +28,3 @@ Please note that this documentation and any contributions are subject to the Cre
 Copyright (C) 2021 Liferay, Inc. All rights reserved. 
 
 <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
-

--- a/README.md
+++ b/README.md
@@ -22,3 +22,10 @@ Please report any issues by creating an issue ticket for Project `PUBLIC - Lifer
 If you'd like to contribute example code for a tutorial, please follow the [Tutorial Code Guidelines](./readme/TUTORIAL_CODE_GUIDELINES.md).
 
 If you'd like to specifically contribute example code for a REST API tutorial, please follow the [REST API Project Guidelines](./readme/REST_API_PROJECT_GUIDELINES.md).
+
+Please note that this documentation and any contributions are subject to the Creative Commons license below. 
+
+Copyright (C) 2021 Liferay, Inc. All rights reserved. 
+
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br />This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.
+

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme P1Z2 Web
+Bundle-SymbolicName: com.acme.p1z2.web
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/configuration/P1Z2WebPortletInstanceConfiguration.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/configuration/P1Z2WebPortletInstanceConfiguration.java
@@ -1,0 +1,30 @@
+package com.acme.p1z2.web.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+@ExtendedObjectClassDefinition(
+	category = "p1z2",
+	scope = ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE
+)
+@Meta.OCD(
+	id = "com.acme.p1z2.web.internal.configuration.P1Z2WebPortletInstanceConfiguration",
+	localization = "content/Language",
+	name = "p1z2-web-portlet-instance-configuration-name"
+)
+public interface P1Z2WebPortletInstanceConfiguration {
+
+	@Meta.AD(
+		deflt = "Configuration Framework 1", name = "configuration-source",
+		optionLabels = {
+			"Configuration Framework 1", "Configuration Framework 2"
+		},
+		optionValues = {
+			"Configuration Framework 1", "Configuration Framework 2"
+		},
+		required = false
+	)
+	public String configurationSource();
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/portlet/P1Z2Portlet.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/portlet/P1Z2Portlet.java
@@ -1,0 +1,61 @@
+package com.acme.p1z2.web.internal.portlet;
+
+import com.acme.p1z2.web.internal.configuration.P1Z2WebPortletInstanceConfiguration;
+
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.IOException;
+
+import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	configurationPid = "com.acme.p1z2.web.internal.configuration.P1Z2WebPortletInstanceConfiguration",
+	property = {
+		"com.liferay.portlet.display-category=category.sample",
+		"javax.portlet.display-name=P1Z2 Portlet",
+		"javax.portlet.init-param.config-template=/configuration.jsp",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=P1Z2Portlet",
+		"javax.portlet.resource-bundle=content.Language"
+	},
+	service = Portlet.class
+)
+public class P1Z2Portlet extends MVCPortlet {
+
+	@Override
+	public void render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		try {
+			P1Z2WebPortletInstanceConfiguration
+				p1z2WebPortletInstanceConfiguration =
+					portletDisplay.getPortletInstanceConfiguration(
+						P1Z2WebPortletInstanceConfiguration.class);
+
+			renderRequest.setAttribute(
+				P1Z2WebPortletInstanceConfiguration.class.getName(),
+				p1z2WebPortletInstanceConfiguration);
+		}
+		catch (ConfigurationException configurationException) {
+			throw new PortletException(configurationException);
+		}
+
+		super.render(renderRequest, renderResponse);
+	}
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/portlet/action/P1Z2WebPortletInstanceConfigurationAction.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/portlet/action/P1Z2WebPortletInstanceConfigurationAction.java
@@ -1,0 +1,80 @@
+package com.acme.p1z2.web.internal.portlet.action;
+
+import com.acme.p1z2.web.internal.configuration.P1Z2WebPortletInstanceConfiguration;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.ConfigurationAction;
+import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletConfig;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+@Component(
+	configurationPid = "com.acme.p1z2.web.internal.configuration.P1Z2WebPortletInstanceConfiguration",
+	configurationPolicy = ConfigurationPolicy.OPTIONAL,
+	property = "javax.portlet.name=P1Z2Portlet",
+	service = ConfigurationAction.class
+)
+public class P1Z2WebPortletInstanceConfigurationAction
+	extends DefaultConfigurationAction {
+
+	@Override
+	public void include(
+			PortletConfig portletConfig, HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse)
+		throws Exception {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		try {
+			P1Z2WebPortletInstanceConfiguration
+				p1z2WebPortletInstanceConfiguration =
+					portletDisplay.getPortletInstanceConfiguration(
+						P1Z2WebPortletInstanceConfiguration.class);
+
+			httpServletRequest.setAttribute(
+				P1Z2WebPortletInstanceConfiguration.class.getName(),
+				p1z2WebPortletInstanceConfiguration);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+		}
+
+		super.include(portletConfig, httpServletRequest, httpServletResponse);
+	}
+
+	@Override
+	public void processAction(
+			PortletConfig portletConfig, ActionRequest actionRequest,
+			ActionResponse actionResponse)
+		throws Exception {
+
+		String configurationSource = ParamUtil.getString(
+			actionRequest, "configurationSource");
+
+		setPreference(
+			actionRequest, "configurationSource", configurationSource);
+
+		super.processAction(portletConfig, actionRequest, actionResponse);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		P1Z2WebPortletInstanceConfigurationAction.class);
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/settings/definition/P1Z2WebPortletInstanceConfigurationBeanDeclaration.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/settings/definition/P1Z2WebPortletInstanceConfigurationBeanDeclaration.java
@@ -1,0 +1,18 @@
+package com.acme.p1z2.web.internal.settings.definition;
+
+import com.acme.p1z2.web.internal.configuration.P1Z2WebPortletInstanceConfiguration;
+
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = ConfigurationBeanDeclaration.class)
+public class P1Z2WebPortletInstanceConfigurationBeanDeclaration
+	implements ConfigurationBeanDeclaration {
+
+	@Override
+	public Class<?> getConfigurationBeanClass() {
+		return P1Z2WebPortletInstanceConfiguration.class;
+	}
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -1,0 +1,43 @@
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
+
+<%@ page import="com.acme.p1z2.web.internal.configuration.P1Z2WebPortletInstanceConfiguration" %>
+
+<%@ page import="com.liferay.petra.string.StringPool" %><%@
+page import="com.liferay.portal.kernel.util.Constants" %>
+
+<liferay-theme:defineObjects />
+
+<portlet:defineObjects />
+
+<%
+String configurationSource = StringPool.BLANK;
+P1Z2WebPortletInstanceConfiguration p1z2WebPortletInstanceConfiguration = (P1Z2WebPortletInstanceConfiguration)renderRequest.getAttribute(P1Z2WebPortletInstanceConfiguration.class.getName());
+
+if (p1z2WebPortletInstanceConfiguration != null) {
+	configurationSource = portletPreferences.getValue("configurationSource", p1z2WebPortletInstanceConfiguration.configurationSource());
+}
+%>
+
+<liferay-portlet:actionURL portletConfiguration="<%= true %>" var="configurationActionURL" />
+
+<liferay-portlet:renderURL portletConfiguration="<%= true %>" var="configurationRenderURL" />
+
+<aui:form action="<%= configurationActionURL %>" method="post" name="fm">
+	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
+	<aui:input name="redirect" type="hidden" value="<%= configurationRenderURL %>" />
+
+	<aui:fieldset>
+		<aui:select label="Portlet Preference" name="configurationSource" value="<%= configurationSource %>">
+			<aui:option value="Portlet Preference 1">Portlet Preference 1</aui:option>
+			<aui:option value="Portlet Preference 2">Portlet Preference 2</aui:option>
+		</aui:select>
+	</aui:fieldset>
+
+	<aui:button-row>
+		<aui:button type="submit"></aui:button>
+	</aui:button-row>
+</aui:form>

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/resources/META-INF/resources/view.jsp
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,12 @@
+<%@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<%@ page import="com.acme.p1z2.web.internal.configuration.P1Z2WebPortletInstanceConfiguration" %>
+
+<%
+P1Z2WebPortletInstanceConfiguration p1z2WebPortletInstanceConfiguration = (P1Z2WebPortletInstanceConfiguration)request.getAttribute(P1Z2WebPortletInstanceConfiguration.class.getName());
+%>
+
+<h1><liferay-ui:message key="p1z2-portlet-welcome" /></h1>
+<p>
+	<liferay-ui:message key="configuration-source" />: <liferay-ui:message key="<%= p1z2WebPortletInstanceConfiguration.configurationSource() %>" />
+</p>

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/resources/content/Language.properties
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-p1z2.zip/p1z2-web/src/main/resources/content/Language.properties
@@ -1,0 +1,3 @@
+configuration-source=Configuration Source
+p1z2-web-portlet-instance-configuration-name=P1Z2 Web Portlet Instance Configuration
+p1z2-portlet-welcome=P1Z2 Portlet - Welcome!


### PR DESCRIPTION
https://issues.liferay.com/browse/LRDOCS-9544

A tutorial that demonstrates the interplay between the Configuration Framework at the Portlet scoped level and Portlet Preferences with configuration action.

So a few things to note for this sample code:

* Portlet preference and configuration action is outside the realm of the Configuration framework (i.e. Portlet preferences get saved to a different database than configuration framework) but Russ thought it would be good to have this article that discusses the interplay. It's likely that a developer will want to learn how to do both together.
* So the example is meant to show that when the Portlet is first deployed the configuration is coming from the Configuration Framework. But once you change the Portlet preference, from that point on your saving the configuration to Portlet preference.
* I am using PortletDisplay instead of ConfigurationProvider. PortletDisplay runs ConfigurationProvider under the hood. I could have just used ConfigurationProvider instead to not have to introduce another method to the reader but I see that Portal typically uses PortletDisplay for PortletInstance scoped configurations. So I chose to do the same and use PortletDisplay.
* In theory I didn't have to use PortletInstance scope for this example. The default value could have come from Site scope, Instance scope, System scope, etc. But Russ was mentioning that it is maybe good practice to mark the configuration interface as PortletInstance scoped as a reminder for the developer of what the Portlet configuration is going to be used for.