### PR TITLE
LRDOCS-9649 ContentStructures and ContentTemplate REST API cURL scripts

### DIFF
--- a/docs/dxp/latest/en/content-authoring-and-management/web-content/developer-guide/managing-structures-and-templates-by-using-the-rest-api/resources/m7b1.zip/curl/ContentStructure_GET_Permissions.sh
+++ b/docs/dxp/latest/en/content-authoring-and-management/web-content/developer-guide/managing-structures-and-templates-by-using-the-rest-api/resources/m7b1.zip/curl/ContentStructure_GET_Permissions.sh
@@ -1,0 +1,3 @@
+curl \
+		"http://localhost:8080/o/headless-delivery/v1.0/content-structures/${1}/permissions" \
+		-u "test@liferay.com:test"

--- a/docs/dxp/latest/en/content-authoring-and-management/web-content/developer-guide/managing-structures-and-templates-by-using-the-rest-api/resources/m7b1.zip/curl/ContentStructure_PUT_Permissions.sh
+++ b/docs/dxp/latest/en/content-authoring-and-management/web-content/developer-guide/managing-structures-and-templates-by-using-the-rest-api/resources/m7b1.zip/curl/ContentStructure_PUT_Permissions.sh
@@ -1,0 +1,6 @@
+curl \
+	-H "Content-Type: application/json" \
+	-X PUT \
+	"http://localhost:8080/o/headless-delivery/v1.0/content-structures/${1}/permissions" \
+    -d "[{\"actionIds\": [\"DELETE\", \"VIEW\"], \"roleName\": \"Power User\"}]" \
+	-u "test@liferay.com:test"

--- a/docs/dxp/latest/en/content-authoring-and-management/web-content/developer-guide/managing-structures-and-templates-by-using-the-rest-api/resources/m7b1.zip/curl/ContentStructures_GET_FromSite.sh
+++ b/docs/dxp/latest/en/content-authoring-and-management/web-content/developer-guide/managing-structures-and-templates-by-using-the-rest-api/resources/m7b1.zip/curl/ContentStructures_GET_FromSite.sh
@@ -1,0 +1,3 @@
+curl \
+		"http://localhost:8080/o/headless-delivery/v1.0/sites/${1}/content-structures" \
+		-u "test@liferay.com:test"

--- a/docs/dxp/latest/en/content-authoring-and-management/web-content/developer-guide/managing-structures-and-templates-by-using-the-rest-api/resources/m7b1.zip/curl/ContentTemplates_GET_FromSite.sh
+++ b/docs/dxp/latest/en/content-authoring-and-management/web-content/developer-guide/managing-structures-and-templates-by-using-the-rest-api/resources/m7b1.zip/curl/ContentTemplates_GET_FromSite.sh
@@ -1,0 +1,3 @@
+curl \
+		"http://localhost:8080/o/headless-delivery/v1.0/sites/${1}/content-templates" \
+		-u "test@liferay.com:test"


### PR DESCRIPTION
This PR proposes the following four cURL scripts for the `ContentStructures` and `ContentTemplates` REST API developer tutorial:

- GET Structures
- GET Templates
- GET Structures permissions
- PUT Structures permissions

This is based on the Jira ticket [LRDOCS-9649](https://issues.liferay.com/browse/LRDOCS-9649). The corresponding markdown article will be sent on a different PR after this PR review.

cc: @sez11a, @jrhoun