### PR TITLE
LRDOCS-9544 Portlet with Configuration

### DIFF
--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/portlet-preferences/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/configuration/P1Z2WebConfiguration.java
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/portlet-preferences/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/configuration/P1Z2WebConfiguration.java
@@ -1,0 +1,24 @@
+package com.acme.p1z2.web.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+@ExtendedObjectClassDefinition(
+	category = "p1z2",
+	scope = ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE
+)
+@Meta.OCD(
+	id = "com.acme.p1z2.web.internal.configuration.P1Z2WebConfiguration",
+	name = "P1Z2 Portlet"
+)
+public interface P1Z2WebConfiguration {
+
+	@Meta.AD(
+		deflt = "green", name = "color",
+		optionLabels = {"Green", "Orange", "Purple"},
+		optionValues = {"green", "orange", "purple"}, required = false
+	)
+	public String color();
+
+}

--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/portlet-preferences/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/portlet/P1Z2Portlet.java
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/portlet-preferences/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/portlet/P1Z2Portlet.java
@@ -1,12 +1,24 @@
 package com.acme.p1z2.web.internal.portlet;
 
+import com.acme.p1z2.web.internal.configuration.P1Z2WebConfiguration;
+
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.IOException;
 
 import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
 
 @Component(
+	configurationPid = "com.acme.p1z2.web.internal.configuration.P1Z2WebConfiguration",
 	property = {
 		"com.liferay.portlet.display-category=category.sample",
 		"javax.portlet.display-name=P1Z2 Portlet",
@@ -17,4 +29,30 @@ import org.osgi.service.component.annotations.Component;
 	service = Portlet.class
 )
 public class P1Z2Portlet extends MVCPortlet {
+
+	@Override
+	public void render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		try {
+			P1Z2WebConfiguration p1z2WebConfiguration =
+				portletDisplay.getPortletInstanceConfiguration(
+					P1Z2WebConfiguration.class);
+
+			renderRequest.setAttribute(
+				P1Z2WebConfiguration.class.getName(), p1z2WebConfiguration);
+		}
+		catch (ConfigurationException configurationException) {
+			throw new PortletException(configurationException);
+		}
+
+		super.render(renderRequest, renderResponse);
+	}
+
 }

--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/portlet-preferences/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/settings/definition/P1Z2WebConfigurationBeanDeclaration.java
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/portlet-preferences/resources/liferay-p1z2.zip/p1z2-web/src/main/java/com/acme/p1z2/web/internal/settings/definition/P1Z2WebConfigurationBeanDeclaration.java
@@ -1,0 +1,18 @@
+package com.acme.p1z2.web.internal.settings.definition;
+
+import com.acme.p1z2.web.internal.configuration.P1Z2WebConfiguration;
+
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = ConfigurationBeanDeclaration.class)
+public class P1Z2WebConfigurationBeanDeclaration
+	implements ConfigurationBeanDeclaration {
+
+	@Override
+	public Class<?> getConfigurationBeanClass() {
+		return P1Z2WebConfiguration.class;
+	}
+
+}

--- a/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/portlet-preferences/resources/liferay-p1z2.zip/p1z2-web/src/main/resources/META-INF/resources/view.jsp
+++ b/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/portlet-preferences/resources/liferay-p1z2.zip/p1z2-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,7 +1,22 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %>
+<%@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<%@ page import="com.acme.p1z2.web.internal.configuration.P1Z2WebConfiguration" %>
 
 <portlet:defineObjects />
 
-Color: <%= (String)portletPreferences.getValue("color", "blue") %>
+<%
+P1Z2WebConfiguration p1z2WebConfiguration = (P1Z2WebConfiguration)request.getAttribute(P1Z2WebConfiguration.class.getName());
+String preference = (String)portletPreferences.getValue("color", "");
+
+if (preference.equals("")) {
+	preference = p1z2WebConfiguration.color();
+}
+else {
+	preference = (String)portletPreferences.getValue("color", "");
+}
+%>
+
+Color: <%= preference %>


### PR DESCRIPTION
Hi Jim, 

I was hoping that you could review my code. This is what I plan to include in the portlet configuration article in which the reader takes the P1Z2 portlet preference sample and adds a configuration UI to system settings. A few questions I  had:

1. Do you think this is too much code for a reader to add by themselves as they read the article?
2. In Portal, the naming convention for the configuration interface is typically xxxPortletInstanceConfiguration.java. Should I use the same convention? 
3. I’m using the PortletDisplay method to get PortletInstance configuration (instead of ConfigurationProvider). This is what I see typically in Portal. It's a new class/method I will introduce in the article. Is that okay?
4. I didn’t add a ConfigurationCategory, do you think I should add one? Or just reference my article about it?
