### PR TITLE
LRDOCS-9544 Portlet Configuration

### DIFF
--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/bnd.bnd
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Acme X7Y2 Web
+Bundle-SymbolicName: com.acme.x7y2.web
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/build.gradle
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/java/com/acme/x7y2/web/internal/configuration/X7Y2WebPortletInstanceConfiguration.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/java/com/acme/x7y2/web/internal/configuration/X7Y2WebPortletInstanceConfiguration.java
@@ -1,0 +1,24 @@
+package com.acme.x7y2.web.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+@ExtendedObjectClassDefinition(
+	category = "x7y2",
+	scope = ExtendedObjectClassDefinition.Scope.PORTLET_INSTANCE
+)
+@Meta.OCD(
+	id = "com.acme.x7y2.web.internal.configuration.X7Y2WebPortletInstanceConfiguration",
+	name = "X7Y2 Portlet"
+)
+public interface X7Y2WebPortletInstanceConfiguration {
+
+	@Meta.AD(
+		deflt = "green", name = "color",
+		optionLabels = {"Green", "Orange", "Purple"},
+		optionValues = {"green", "orange", "purple"}, required = false
+	)
+	public String color();
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/java/com/acme/x7y2/web/internal/portlet/X7Y2Portlet.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/java/com/acme/x7y2/web/internal/portlet/X7Y2Portlet.java
@@ -1,0 +1,60 @@
+package com.acme.x7y2.web.internal.portlet;
+
+import com.acme.x7y2.web.internal.configuration.X7Y2WebPortletInstanceConfiguration;
+
+import com.liferay.portal.kernel.module.configuration.ConfigurationException;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.IOException;
+
+import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(
+	configurationPid = "com.acme.x7y2.web.internal.configuration.X7Y2WebPortletInstanceConfiguration",
+	property = {
+		"com.liferay.portlet.display-category=category.sample",
+		"javax.portlet.display-name=X7Y2 Portlet",
+		"javax.portlet.init-param.config-template=/configuration.jsp",
+		"javax.portlet.init-param.view-template=/view.jsp",
+		"javax.portlet.name=com_acme_x7y2_web_internal_portlet_X7Y2Portlet"
+	},
+	service = Portlet.class
+)
+public class X7Y2Portlet extends MVCPortlet {
+
+	@Override
+	public void render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		try {
+			X7Y2WebPortletInstanceConfiguration
+				x7y2WebPortletInstanceConfiguration =
+					portletDisplay.getPortletInstanceConfiguration(
+						X7Y2WebPortletInstanceConfiguration.class);
+
+			renderRequest.setAttribute(
+				X7Y2WebPortletInstanceConfiguration.class.getName(),
+				x7y2WebPortletInstanceConfiguration);
+		}
+		catch (ConfigurationException configurationException) {
+			throw new PortletException(configurationException);
+		}
+
+		super.render(renderRequest, renderResponse);
+	}
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/java/com/acme/x7y2/web/internal/portlet/action/X7Y2WebPortletInstanceConfigurationAction.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/java/com/acme/x7y2/web/internal/portlet/action/X7Y2WebPortletInstanceConfigurationAction.java
@@ -1,0 +1,35 @@
+package com.acme.x7y2.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.portlet.ConfigurationAction;
+import com.liferay.portal.kernel.portlet.DefaultConfigurationAction;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+import javax.portlet.PortletConfig;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.ConfigurationPolicy;
+
+@Component(
+	configurationPolicy = ConfigurationPolicy.OPTIONAL,
+	property = "javax.portlet.name=com_acme_x7y2_web_internal_portlet_X7Y2Portlet",
+	service = ConfigurationAction.class
+)
+public class X7Y2WebPortletInstanceConfigurationAction
+	extends DefaultConfigurationAction {
+
+	@Override
+	public void processAction(
+			PortletConfig portletConfig, ActionRequest actionRequest,
+			ActionResponse actionResponse)
+		throws Exception {
+
+		setPreference(
+			actionRequest, "color",
+			ParamUtil.getString(actionRequest, "color"));
+
+		super.processAction(portletConfig, actionRequest, actionResponse);
+	}
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/java/com/acme/x7y2/web/internal/settings/definition/X7Y2WebPortletInstanceConfigurationBeanDeclaration.java
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/java/com/acme/x7y2/web/internal/settings/definition/X7Y2WebPortletInstanceConfigurationBeanDeclaration.java
@@ -1,0 +1,18 @@
+package com.acme.x7y2.web.internal.settings.definition;
+
+import com.acme.x7y2.web.internal.configuration.X7Y2WebPortletInstanceConfiguration;
+
+import com.liferay.portal.kernel.settings.definition.ConfigurationBeanDeclaration;
+
+import org.osgi.service.component.annotations.Component;
+
+@Component(service = ConfigurationBeanDeclaration.class)
+public class X7Y2WebPortletInstanceConfigurationBeanDeclaration
+	implements ConfigurationBeanDeclaration {
+
+	@Override
+	public Class<?> getConfigurationBeanClass() {
+		return X7Y2WebPortletInstanceConfiguration.class;
+	}
+
+}

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -1,0 +1,30 @@
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %>
+
+<%@ page import="com.liferay.portal.kernel.util.Constants" %>
+
+<portlet:defineObjects />
+
+<liferay-portlet:actionURL portletConfiguration="<%= true %>" var="configurationActionURL" />
+
+<aui:form action="<%= configurationActionURL %>" method="post" name="fm">
+	<aui:input name="<%= Constants.CMD %>" type="hidden" value="<%= Constants.UPDATE %>" />
+
+	<liferay-portlet:renderURL portletConfiguration="<%= true %>" var="configurationRenderURL" />
+
+	<aui:input name="redirect" type="hidden" value="<%= configurationRenderURL %>" />
+
+	<aui:fieldset>
+		<aui:select label="color" name="color" value='<%= (String)portletPreferences.getValue("color", "blue") %>'>
+			<aui:option label="Blue" value="blue" />
+			<aui:option label="Red" value="red" />
+			<aui:option label="Yellow" value="yellow" />
+		</aui:select>
+	</aui:fieldset>
+
+	<aui:button-row>
+		<aui:button type="submit" />
+	</aui:button-row>
+</aui:form>

--- a/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/resources/META-INF/resources/view.jsp
+++ b/docs/dxp/latest/en/developing-applications/core-frameworks/configurable-application/portlet-level-configuration/resources/liferay-x7y2.zip/x7y2-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,0 +1,22 @@
+<%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
+
+<%@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
+taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+
+<%@ page import="com.acme.x7y2.web.internal.configuration.X7Y2WebPortletInstanceConfiguration" %>
+
+<portlet:defineObjects />
+
+<%
+X7Y2WebPortletInstanceConfiguration x7y2WebPortletInstanceConfiguration = (X7Y2WebPortletInstanceConfiguration)request.getAttribute(X7Y2WebPortletInstanceConfiguration.class.getName());
+String preference = (String)portletPreferences.getValue("color", "");
+
+if (preference.equals("")) {
+	preference = x7y2WebPortletInstanceConfiguration.color();
+}
+else {
+	preference = (String)portletPreferences.getValue("color", "");
+}
+%>
+
+Color: <%= preference %>


### PR DESCRIPTION
This is starting off with the same codebase as Portlet Preferences ([P1Z2 Portlet](https://github.com/liferay/liferay-learn/tree/master/docs/dxp/latest/en/developing-applications/developing-a-java-web-application/using-mvc/portlet-preferences/resources/liferay-p1z2.zip/p1z2-web)) but adding a configuration interface so that a UI appears in system settings.

The expected behavior is that a user can set a default color in system settings (green, orange, purple) so that when the portlet is deployed, this selection will show up by default. But once a user selects a portlet preference (blue, red, yellow), that choice will supersede the system settings.