### PR TITLE
LRDOCS-9412 Theme contributors example

### DIFF
--- a/docs/dxp/latest/en/site-building/site-appearance/themes/theme-development/bundling-resources/bundling-independent-ui-resources-via-theme-contributors/resources/liferay-w9m6.zip/w9m6-web/bnd.bnd
+++ b/docs/dxp/latest/en/site-building/site-appearance/themes/theme-development/bundling-resources/bundling-independent-ui-resources-via-theme-contributors/resources/liferay-w9m6.zip/w9m6-web/bnd.bnd
@@ -1,0 +1,6 @@
+Bundle-Name: Acme W9M6 Web
+Bundle-SymbolicName: com.acme.w9m6.web
+Bundle-Version: 1.0.0
+Liferay-Theme-Contributor-Type: CSS
+Liferay-Theme-Contributor-Weight: 1
+Web-ContextPath: /w9m6-web

--- a/docs/dxp/latest/en/site-building/site-appearance/themes/theme-development/bundling-resources/bundling-independent-ui-resources-via-theme-contributors/resources/liferay-w9m6.zip/w9m6-web/build.gradle
+++ b/docs/dxp/latest/en/site-building/site-appearance/themes/theme-development/bundling-resources/bundling-independent-ui-resources-via-theme-contributors/resources/liferay-w9m6.zip/w9m6-web/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/site-building/site-appearance/themes/theme-development/bundling-resources/bundling-independent-ui-resources-via-theme-contributors/resources/liferay-w9m6.zip/w9m6-web/src/main/resources/META-INF/resources/css/custom.css
+++ b/docs/dxp/latest/en/site-building/site-appearance/themes/theme-development/bundling-resources/bundling-independent-ui-resources-via-theme-contributors/resources/liferay-w9m6.zip/w9m6-web/src/main/resources/META-INF/resources/css/custom.css
@@ -1,0 +1,3 @@
+body, #wrapper {
+    background: blue;
+} 


### PR DESCRIPTION
See: https://issues.liferay.com/browse/LRDOCS-9412

Re-sent from: https://github.com/jhinkey/liferay-learn/pull/111

Here's the new branch with just the code. I also went ahead and rewrote parts of the article as you suggested. If you'd like to see that too, here is a branch with just the Markdown including those changes: https://github.com/Alec-Shay/liferay-learn/tree/LRDOCS-9412-article-only    (or [this link directly to the article](https://github.com/Alec-Shay/liferay-learn/blob/67e40b88a498b52a66c6ce9bbe90fee99b3211ed/docs/dxp/latest/en/site-building/site-appearance/themes/theme-development/bundling-resources/bundling-independent-ui-resources-via-theme-contributors.md)).

Let me know what you think now when you get the chance. Thanks again.

From the previous PR:

> This is a new/rewritten version of the old tutorial on Help Center for creating a theme contributor, previously here: https://help.liferay.com/hc/es/articles/360028726532-Packaging-Independent-UI-Resources-for-Your-Site
> 
> Note that LRDOCS-9412 is associated with tickets representing a broader initiative to port frontend materials to Liferay Learn (in this case, [IFI-2295](https://issues.liferay.com/browse/IFI-2295).
> 
> Also note that the ticket also calls for porting another article (about a Kickstart task used to copy theme files) that was not included here because it seemed to me like a separate task. So I instead created a subtask for that which I am hoping can be done at a later date.