### PR TITLE
search 7.x | queries and filters | LRDOCS-7800

### DIFF
--- a/docs/dxp/latest/en/installation-and-upgrades/upgrading-liferay/reference.rst
+++ b/docs/dxp/latest/en/installation-and-upgrades/upgrading-liferay/reference.rst
@@ -12,6 +12,7 @@ Reference
    reference/maintenance-mode-and-deprecations-in-7-4.md
    reference/maintenance-mode-and-deprecations-in-7-3.md
    reference/maintenance-mode-and-deprecations-in-7-2.md
+   reference/renamed-language-keys.md
    reference/troubleshooting-upgrades.md
 
 -  :doc:`/installation-and-upgrades/upgrading-liferay/reference/data-cleanup`
@@ -22,4 +23,5 @@ Reference
 -  :doc:`/installation-and-upgrades/upgrading-liferay/reference/maintenance-mode-and-deprecations-in-7-4`
 -  :doc:`/installation-and-upgrades/upgrading-liferay/reference/maintenance-mode-and-deprecations-in-7-3`
 -  :doc:`/installation-and-upgrades/upgrading-liferay/reference/maintenance-mode-and-deprecations-in-7-2`
+-  :doc:`/installation-and-upgrades/upgrading-liferay/reference/renamed-language-keys`
 -  :doc:`/installation-and-upgrades/upgrading-liferay/reference/troubleshooting-upgrades`

--- a/docs/dxp/latest/en/installation-and-upgrades/upgrading-liferay/reference/renamed-language-keys.md
+++ b/docs/dxp/latest/en/installation-and-upgrades/upgrading-liferay/reference/renamed-language-keys.md
@@ -1,0 +1,3 @@
+# Renamed Language Keys
+
+Coming soon!

--- a/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-global-language-keys.md
+++ b/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-global-language-keys.md
@@ -12,13 +12,15 @@ The global language keys are in the source code and the DXP/Portal bundle.
 
 In the source: 
 
-`/portal-impl/src/content/Language[xx_XX].properties`
+* [`/portal-impl/src/content/Language[_xx_XX].properties`](https://github.com/liferay/liferay-portal/tree/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/content)
+* [`/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language[_xx_XX].properties`](https://github.com/liferay/liferay-portal/tree/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-language/portal-language-lang/src/main/resources/content)
 
 In a bundle:
 
-`portal-impl.jar`
+* `portal-impl.jar#content/Language[_xx_XX].properties`
+* `Liferay * Foundation - Liferay * Portal Language - Impl.lpkg` &rarr; `com.liferay.portal.language.lang-[version].jar#content/Language[_xx_XX].properties`
 
-You can also view the language key files in our [GitHub repository](https://github.com/liferay/liferay-portal/tree/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/content). You can identify the different languages by the language code in the file name suffix. For example `Language_ja.properties` is for Japanese.
+You can identify the different languages by the language code in the file name suffix. For example `Language_ja.properties` is for Japanese.
 
 These language key files contain properties that you can override, like the language settings properties: 
 
@@ -41,7 +43,7 @@ category.cms=Content Management
 ...
 ```
 
-In Liferay DXP/Portal 7.4+, you can use the metadata to declare overrides to the global resource bundle. In earlier versions, Java classes declare the overrides.
+In Liferay DXP/Portal 7.4+, you can declare overrides using metadata. In earlier versions, Java classes declare the overrides.
 
 If your version is earlier than 7.4, skip ahead to [Overriding in Earlier Versions](#overriding-in-earlier-versions). Otherwise, read on to learn how to override language keys in 7.4+.
 
@@ -120,7 +122,7 @@ The values for the language keys you declare override the values for those exist
 Once you've decided which keys to override, create a language properties file in your module's `src/main/resources/content` folder. Use the file name `Language.properties` to override the default locale's language keys. To override a specific locale's keys, use the language properties file naming convention:
 
 ```
-Language[xx_XX].properties
+Language[_xx_XX].properties
 ```
 
 For example, if you're overriding Japanese, use `Language_ja.properties`.
@@ -249,4 +251,4 @@ Deploy your module to see your new language key values.
 
 ## Related Information
 
-* [Overriding Module Language Keys](./overriding-module-language-keys.md)
+* [Overriding Module Language Keys in Earlier Versions](./overriding-module-language-keys.md)

--- a/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-global-language-keys.md
+++ b/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-global-language-keys.md
@@ -249,6 +249,10 @@ private final ResourceBundle _resourceBundle = ResourceBundle.getBundle(
 
 Deploy your module to see your new language key values.
 
+```{note}
+When you're ready to upgrade to DXP 7.4+, you can continue to use your language key override module. Optionally, you can simplify the module by removing the `ResourceBundle` class and specifying the `Provide-Capability` header in your `bnd.bnd` file as demonstrated in the earlier [section](#declare-the-override-in-the-bnd-file).
+```
+
 ## Related Information
 
 * [Overriding Module Language Keys in Earlier Versions](./overriding-module-language-keys.md)

--- a/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-global-language-keys.md
+++ b/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-global-language-keys.md
@@ -12,13 +12,13 @@ The global language keys are in the source code and the DXP/Portal bundle.
 
 In the source: 
 
-* [`/portal-impl/src/content/Language[_xx_XX].properties`](https://github.com/liferay/liferay-portal/tree/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/content)
-* [`/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language[_xx_XX].properties`](https://github.com/liferay/liferay-portal/tree/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-language/portal-language-lang/src/main/resources/content)
+* [`liferay-[dxp|portal]/portal-impl/src/content/Language[_xx_XX].properties`](https://github.com/liferay/liferay-portal/tree/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/portal-impl/src/content)
+* [`liferay-[dxp|portal]/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language[_xx_XX].properties`](https://github.com/liferay/liferay-portal/tree/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-language/portal-language-lang/src/main/resources/content)
 
 In a bundle:
 
 * `portal-impl.jar#content/Language[_xx_XX].properties`
-* `Liferay * Foundation - Liferay * Portal Language - Impl.lpkg` &rarr; `com.liferay.portal.language.lang-[version].jar#content/Language[_xx_XX].properties`
+* `Liferay Foundation - Liferay Portal Language - Impl.lpkg` &rarr; `com.liferay.portal.language.lang-[version].jar#content/Language[_xx_XX].properties`
 
 You can identify the different languages by the language code in the file name suffix. For example `Language_ja.properties` is for Japanese.
 

--- a/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-global-language-keys.md
+++ b/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-global-language-keys.md
@@ -250,7 +250,7 @@ private final ResourceBundle _resourceBundle = ResourceBundle.getBundle(
 Deploy your module to see your new language key values.
 
 ```{note}
-When you're ready to upgrade to DXP 7.4+, you can continue to use your language key override module. Optionally, you can simplify the module by removing the `ResourceBundle` class and specifying the `Provide-Capability` header in your `bnd.bnd` file as demonstrated in the earlier [section](#declare-the-override-in-the-bnd-file).
+When you're ready to upgrade to DXP 7.4+, you can continue to use your language key override module. Optionally, you can simplify the module by removing the `ResourceBundle` class and specifying the `Provide-Capability` header in your `bnd.bnd` file as demonstrated [above](#declare-the-override-in-the-bnd-file).
 ```
 
 ## Related Information

--- a/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-module-language-keys.md
+++ b/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-module-language-keys.md
@@ -204,9 +204,15 @@ The example `Provide-Capability` header has two parts:
     * `service.ranking:Long="2"`: The resource bundle's service ranking is `2`. The OSGi framework applies this service if it outranks all other resource bundle services that target `com.liferay.blogs.web`'s `content.Language` resource bundle. 
     * `servlet.context.name=blogs-web`: The target resource bundle is in servlet context `blogs-web`. 
 
-**Note:** If your override isn't showing, use [Gogo shell](../fundamentals/using-the-gogo-shell/using-the-gogo-shell.md) to check for competing resource bundle services. It may be that another service outranks yours. To check for competing resource bundle services whose aggregates include `com.liferay.blogs.web`’s resource bundle, for example, execute this Gogo shell command:
+```{note}
+If your override isn't showing, use [Gogo shell](../fundamentals/using-the-gogo-shell/using-the-gogo-shell.md) to check for competing resource bundle services. It may be that another service outranks yours. To check for competing resource bundle services whose aggregates include `com.liferay.blogs.web`’s resource bundle, for example, execute this Gogo shell command:
 
-    services "(bundle.symbolic.name=com.liferay.blogs.web)"
+`services "(bundle.symbolic.name=com.liferay.blogs.web)"`
+```
+
+```{note}
+You can continue to use your language key override in DXP 7.4+ if the language key name is the same---check the [`/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language[_xx_XX].properties`](https://github.com/liferay/liferay-portal/tree/[$LIFERAY_LEARN_PORTAL_GIT_TAG$]/modules/apps/portal-language/portal-language-lang/src/main/resources/content) file. Optionally, you can simplify your module by removing the `ResourceBundle` class and replacing the `Provide-Capability` header in your `bnd.bnd` file with the header demonstrated in the [Overriding Global Language Keys](./overriding-global-language-keys.md#declare-the-oOverride-in-the-bnd-file).
+```
 
 Search the results for resource bundle aggregate services whose ranking is higher.
 

--- a/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-module-language-keys.md
+++ b/docs/dxp/latest/en/liferay-internals/extending-liferay/overriding-module-language-keys.md
@@ -1,6 +1,10 @@
-# Overriding Module Language Keys
+# Overriding Module Language Keys in Earlier Versions
 
-The language keys of a module can be overridden just like how [global language keys can be overridden](./overriding-global-language-keys.md). The steps are slightly different when working with a module. 
+```{important}
+If you're working with Liferay DXP/Portal 7.4+, please follow the instructions for [Overriding Global Language Keys](./overriding-global-language-keys.md).
+```
+
+Overriding Liferay application specific language keys in earlier versions is similar to overriding global language keys in earlier versions but there are additional steps. 
 
 ## Examining Module Language Keys
 

--- a/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/bnd.bnd
+++ b/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Search Queries and Filters Sample
+Bundle-SymbolicName: com.liferay.search.samples.osgi.commands
+Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/bnd.bnd
+++ b/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/bnd.bnd
@@ -1,3 +1,3 @@
-Bundle-Name: Liferay Search Queries and Filters Sample
-Bundle-SymbolicName: com.liferay.search.samples.osgi.commands
+Bundle-Name: Acme R2D2 OSGi Command
+Bundle-SymbolicName: com.acme.r2d2.osgi.commands
 Bundle-Version: 1.0.0

--- a/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/build.gradle
+++ b/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/build.gradle
@@ -1,0 +1,3 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "release.portal.api"
+}

--- a/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/java/com/liferay/search/samples/osgi/commands/QueriesAndFiltersOSGiCommand.java
+++ b/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/java/com/liferay/search/samples/osgi/commands/QueriesAndFiltersOSGiCommand.java
@@ -1,0 +1,100 @@
+/**
+ * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
+ * SPDX-License-Identifier: MIT
+ */
+
+package com.liferay.search.samples.osgi.commands;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.search.document.Document;
+import com.liferay.portal.search.hits.SearchHit;
+import com.liferay.portal.search.hits.SearchHits;
+import com.liferay.portal.search.query.BooleanQuery;
+import com.liferay.portal.search.query.MatchQuery;
+import com.liferay.portal.search.query.Queries;
+import com.liferay.portal.search.query.TermQuery;
+import com.liferay.portal.search.searcher.SearchRequest;
+import com.liferay.portal.search.searcher.SearchRequestBuilder;
+import com.liferay.portal.search.searcher.SearchRequestBuilderFactory;
+import com.liferay.portal.search.searcher.SearchResponse;
+import com.liferay.portal.search.searcher.Searcher;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+@Component(
+	property = {"osgi.command.function=search", "osgi.command.scope=liferay"},
+	service = QueriesAndFiltersOSGiCommand.class
+)
+public class QueriesAndFiltersOSGiCommand {
+
+	public void search(String keywords) {
+		MatchQuery titleQuery = _queries.match(
+			StringBundler.concat(
+				"localized_", Field.TITLE, StringPool.UNDERLINE, LocaleUtil.US),
+			keywords);
+
+		TermQuery rootFolderQuery = _queries.term(Field.FOLDER_ID, "0");
+
+		BooleanQuery booleanQuery = _queries.booleanQuery();
+
+		booleanQuery.addMustQueryClauses(rootFolderQuery, titleQuery);
+
+		SearchRequestBuilder searchRequestBuilder =
+			_searchRequestBuilderFactory.builder();
+
+		long companyId = _portal.getDefaultCompanyId();
+
+		searchRequestBuilder.withSearchContext(
+			searchContext -> {
+				searchContext.setCompanyId(companyId);
+				searchContext.setKeywords(keywords);
+			});
+
+		SearchRequest searchRequest = searchRequestBuilder.query(
+			booleanQuery
+		).build();
+
+		SearchResponse searchResponse = _searcher.search(searchRequest);
+
+		SearchHits searchHits = searchResponse.getSearchHits();
+
+		List<SearchHit> searchHitsList = searchHits.getSearchHits();
+
+		List<String> resultsList = new ArrayList<>(searchHitsList.size());
+
+		searchHitsList.forEach(
+			searchHit -> {
+				Document doc = searchHit.getDocument();
+
+				String uid = doc.getString(Field.UID);
+
+				System.out.println(
+					StringBundler.concat(
+						"Document ", uid, " had a score of ",
+						searchHit.getScore()));
+
+				resultsList.add(uid);
+			});
+	}
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private Queries _queries;
+
+	@Reference
+	private Searcher _searcher;
+
+	@Reference
+	private SearchRequestBuilderFactory _searchRequestBuilderFactory;
+
+}

--- a/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/java/com/liferay/search/samples/osgi/commands/QueriesAndFiltersOSGiCommand.java
+++ b/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/java/com/liferay/search/samples/osgi/commands/QueriesAndFiltersOSGiCommand.java
@@ -1,8 +1,3 @@
-/**
- * SPDX-FileCopyrightText: © 2021 Liferay, Inc. <https://liferay.com>
- * SPDX-License-Identifier: MIT
- */
-
 package com.liferay.search.samples.osgi.commands;
 
 import com.liferay.petra.string.StringBundler;

--- a/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/java/com/liferay/search/samples/osgi/commands/R2D2OSGiCommand.java
+++ b/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/java/com/liferay/search/samples/osgi/commands/R2D2OSGiCommand.java
@@ -25,10 +25,10 @@ import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
 @Component(
-	property = {"osgi.command.function=search", "osgi.command.scope=liferay"},
-	service = QueriesAndFiltersOSGiCommand.class
+	property = {"osgi.command.function=search", "osgi.command.scope=r2d2"},
+	service = R2D2OSGiCommand.class
 )
-public class QueriesAndFiltersOSGiCommand {
+public class R2D2OSGiCommand {
 
 	public void search(String keywords) {
 		MatchQuery titleQuery = _queries.match(

--- a/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/resources/headless-demo-content/DemoContent_Post_ToSite.sh
+++ b/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/resources/headless-demo-content/DemoContent_Post_ToSite.sh
@@ -1,0 +1,74 @@
+# $1 is the liferay site ID, $2 is the global site ID--both are now found in site settings > site configuration (7.4.2-ga3)
+
+if [ "${#}" -ne 2 ]
+then
+	echo "ERROR"
+	echo "You must pass 2 arguments: the site ID of the default site (e.g., 20125), and the site ID of the global site (e.g., 20127)."
+	echo "To find these IDs, navigate to each site's Site Settings > Site Configuration screen."
+	exit
+fi
+
+# Add a root level document
+curl \
+	-F "document={\"description\": \"Baker\", \"title\": \"Able Document\"}" \
+	-F "file=@test.txt" \
+	-H "Content-Type: multipart/form-data" \
+	-X POST \
+	"http://localhost:8080/o/headless-delivery/v1.0/sites/${1}/documents" \
+	-u "test@liferay.com:test"
+
+# Add the Document Folder
+curl \
+	-H "Content-Type: application/json" \
+	-X POST \
+	"http://localhost:8080/o/headless-delivery/v1.0/sites/${1}/document-folders" \
+	-d "{\"name\": \"Able Document Folder\"}" \
+	-u "test@liferay.com:test"
+
+echo "Enter the ID:"
+read documentFolderId
+
+# Add the Document inside the folder
+curl \
+	-F "document={\"description\": \"Baker\", \"title\": \"Able Document\"}" \
+	-F "file=@test.txt" \
+	-H "Content-Type: multipart/form-data" \
+	-X POST "http://localhost:8080/o/headless-delivery/v1.0/document-folders/${documentFolderId}/documents" \
+	-u "test@liferay.com:test"
+
+# content folder, basic content in folder, root basic content
+
+# Get the basic web content structure ID
+curl \
+	"http://localhost:8080/o/headless-delivery/v1.0/sites/${2}/content-structures?search=Basic%20Web%20Content" \
+	-u "test@liferay.com:test"
+
+echo "Enter the ID:"
+read contentStructuredId
+
+# Add a root level basic web content article
+curl \
+	-H "Content-Type: application/json" \
+	-X POST \
+	"http://localhost:8080/o/headless-delivery/v1.0/sites/${1}/structured-contents" \
+	-d "{\"contentFields\": [{\"contentFieldValue\": {\"data\": \"<p>Foo</p>\"}, \"name\": \"content\"}], \"contentStructureId\": \"${contentStructuredId}\", \"title\": \"Able Article\"}" \
+	-u "test@liferay.com:test"
+
+# Add a web content folder
+curl \
+	-H "Content-Type: application/json" \
+	-X POST \
+	"http://localhost:8080/o/headless-delivery/v1.0/sites/${1}/structured-content-folders" \
+	-d "{\"description\": \"Foo\", \"name\": \"Able Folder\"}" \
+	-u "test@liferay.com:test"
+
+echo "Enter the ID:"
+read structuredContentFolderId
+
+# Add a basic web content article to the folder
+curl \
+	-H "Content-Type: application/json" \
+	-X POST \
+	"http://localhost:8080/o/headless-delivery/v1.0/structured-content-folders/${structuredContentFolderId}/structured-contents" \
+	-d "{\"contentFields\": [{\"contentFieldValue\": {\"data\": \"<p>Foo</p>\"}, \"name\": \"content\"}], \"contentStructureId\": \"${contentStructuredId}\", \"title\": \"Able Article\"}" \
+	-u "test@liferay.com:test"

--- a/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/resources/headless-demo-content/DemoContent_Post_ToSite.sh
+++ b/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/resources/headless-demo-content/DemoContent_Post_ToSite.sh
@@ -10,8 +10,8 @@ fi
 
 # Add a root level document
 curl \
-	-F "document={\"description\": \"Baker\", \"title\": \"Able Document\"}" \
-	-F "file=@test.txt" \
+	-F "document={\"description\": \"Baker\", \"title\": \"Able Root Level Document\"}" \
+	-F "file=@DemoContent_Post_ToSite.sh" \
 	-H "Content-Type: multipart/form-data" \
 	-X POST \
 	"http://localhost:8080/o/headless-delivery/v1.0/sites/${1}/documents" \
@@ -30,8 +30,8 @@ read documentFolderId
 
 # Add the Document inside the folder
 curl \
-	-F "document={\"description\": \"Baker\", \"title\": \"Able Document\"}" \
-	-F "file=@test.txt" \
+	-F "document={\"description\": \"Baker\", \"title\": \"Able Document in Folder\"}" \
+	-F "file=@DemoContent_Post_ToSite.sh" \
 	-H "Content-Type: multipart/form-data" \
 	-X POST "http://localhost:8080/o/headless-delivery/v1.0/document-folders/${documentFolderId}/documents" \
 	-u "test@liferay.com:test"
@@ -51,7 +51,7 @@ curl \
 	-H "Content-Type: application/json" \
 	-X POST \
 	"http://localhost:8080/o/headless-delivery/v1.0/sites/${1}/structured-contents" \
-	-d "{\"contentFields\": [{\"contentFieldValue\": {\"data\": \"<p>Foo</p>\"}, \"name\": \"content\"}], \"contentStructureId\": \"${contentStructuredId}\", \"title\": \"Able Article\"}" \
+	-d "{\"contentFields\": [{\"contentFieldValue\": {\"data\": \"<p>Foo</p>\"}, \"name\": \"content\"}], \"contentStructureId\": \"${contentStructuredId}\", \"title\": \"Able Root Level Article\"}" \
 	-u "test@liferay.com:test"
 
 # Add a web content folder
@@ -59,7 +59,7 @@ curl \
 	-H "Content-Type: application/json" \
 	-X POST \
 	"http://localhost:8080/o/headless-delivery/v1.0/sites/${1}/structured-content-folders" \
-	-d "{\"description\": \"Foo\", \"name\": \"Able Folder\"}" \
+	-d "{\"description\": \"Foo\", \"name\": \"Able Web Content Folder\"}" \
 	-u "test@liferay.com:test"
 
 echo "Enter the ID:"
@@ -70,5 +70,5 @@ curl \
 	-H "Content-Type: application/json" \
 	-X POST \
 	"http://localhost:8080/o/headless-delivery/v1.0/structured-content-folders/${structuredContentFolderId}/structured-contents" \
-	-d "{\"contentFields\": [{\"contentFieldValue\": {\"data\": \"<p>Foo</p>\"}, \"name\": \"content\"}], \"contentStructureId\": \"${contentStructuredId}\", \"title\": \"Able Article\"}" \
+	-d "{\"contentFields\": [{\"contentFieldValue\": {\"data\": \"<p>Foo</p>\"}, \"name\": \"content\"}], \"contentStructureId\": \"${contentStructuredId}\", \"title\": \"Able Article in Folder\"}" \
 	-u "test@liferay.com:test"

--- a/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/resources/headless-demo-content/test.txt
+++ b/docs/dxp/latest/en/using-search/developer-guide/search-queries-and-filters/resources/liferay-r2d2.zip/r2d2-impl/src/main/resources/headless-demo-content/test.txt
@@ -1,0 +1,13 @@
+test 
+test 
+test 
+test 
+test 
+test 
+test 
+test 
+test 
+test 
+test 
+test 
+test 


### PR DESCRIPTION
cc @lipusz
https://issues.liferay.com/browse/LRDOCS-7800

Hi Jim, this is the Search Queries and Filters code sample. 

It contains two main pieces:

1. OSGi command that executes a search query. The query matches the users keywords to the English (US) localized title field (`localized_title_en_US`) and sets a hard-coded query that must match, looking for a `folderId` of `0`. This means that only root-level documents that match the title field will be returned.

1. A `DemoContent_Post_ToSite.sh` script for getting this demo content into the default site:

   - Docs and Media: One root level document and one document in a folder.
   - Basic Web Content: one root level article and one article in a folder.

To test it, run the script (`sh DemoContent_Post_ToSite.sh 20125 20127`), then go to the Gogo shell and type `r2d2:search able`

4 hits are returned:

1. The Able Document Folder
1. The Able Root Level Document
1. The Able Content Folder
1. The Able Root Level Article

The 2 nested pieces of content are not returned: even though they would match the title query, they do not have a `folderId` of `0`.

A couple uncertainties I had:

1. Is the BND metadata I provided accurate for this project? I followed the OSGi command I see in our code base but maybe it should indicate that this is a search query osgi command?

1. The script is inside the `src` folder (`src/main/resources/headless-demo-content/DemoContent_Post_ToSite.sh`), and I don't think Brian like resources that aren't part of the source code to be included here. Let me know if you haver a better approach.

Also keep in mind I have comments in the shell script. These should be removed before sending to Brian. Let me know if you'd like me to do that.