### PR TITLE
LRDOCS-9781 use a tilde ~ to separate factory configuration name from…

### DIFF
--- a/docs/dxp/latest/en/system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md
+++ b/docs/dxp/latest/en/system-administration/configuring-liferay/configuration-files-and-factories/using-factory-configuration.md
@@ -25,26 +25,32 @@ my.service.ServiceConfiguration.config
 If your service supports factory configurations, use the convention of calling the configuration's first instance `-default.config`. The default Organization type is named in this way: 
 
 ```bash
-com.liferay.organizations.internal.configuration.OrganizationTypeConfiguration-default.config
+com.liferay.organizations.internal.configuration.OrganizationTypeConfiguration~default.config
+```
+
+```{note}
+Factory Configuration file names in Liferay  DXP/Portal versions 7.0-7.3 use a dash (`-`) instead of a tilde (`~`) to separate the name from the subname. For example,
+
+`com.liferay.organizations.internal.configuration.OrganizationTypeConfiguration~default.config`
 ```
 
 The next instance contains a unique *subname* (something other than *default*). It's good practice to use a descriptive name that sheds light on when this instance should be used. Following the example from [Adding a New Organization Type](../../../users-and-permissions/organizations/adding-a-new-organization-type.md), you could add the _League_ type with a configuration file named 
 
 ```bash
-com.liferay.organizations.internal.configuration.OrganizationTypeConfiguration-league.config
+com.liferay.organizations.internal.configuration.OrganizationTypeConfiguration~league.config
 ```
 
 ```warning::
    Providing a configuration file with a subname forces a factory configuration scenario, even if the service isn't designed to accept multiple configuration entries. Use the System Settings UI as described above to determine if using factory configurations is supported for a configuration entry. 
 ```
 
-Some System Settings entries that support factory configuration don't ship with a configuration file for the default instance (e.g., the Anonymous User entry). If you export a factory configuration file to obtain the `.config` file, it doesn't use the `-default.config` naming convention. Instead, whether it's the first occurrence or an additional one, it's given a guaranteed unique identifier for its subname:
+Some System Settings entries that support factory configuration don't ship with a configuration file for the default instance (e.g., the Anonymous User entry). If you export a factory configuration file to obtain the `.config` file, it doesn't use the `~default.config` naming convention. Instead, whether it's the first occurrence or an additional one, it's given a guaranteed unique identifier for its subname:
 
 ```bash
-com.liferay.user.associated.data.web.internal.configuration.AnonymousUserConfiguration-6befcd73-7c8b-4597-b396-a18f64f8c308.config
+com.liferay.user.associated.data.web.internal.configuration.AnonymousUserConfiguration~6befcd73-7c8b-4597-b396-a18f64f8c308.config
 ```
 
-If you're exporting the configuration file for deployment in a separate system, you can rename part of the exported filename after the first `-` to use a more descriptive subname. Be careful: if you rename the file and deploy it to the same system it was exported from, the new subname marks it as an entirely new configuration. You'll end up with an additional configuration instance in this case, not just a renamed one.
+If you're exporting the configuration file for deployment in a separate system, you can rename part of the exported filename after the first `~` to use a more descriptive subname. Be careful: if you rename the file and deploy it to the same system it was exported from, the new subname marks it as an entirely new configuration. You'll end up with an additional configuration instance in this case, not just a renamed one.
 
 ```warning::
    For configuration entries supporting factory configurations, omitting the subname from a `.config` file's name causes System Settings to disallow adding new entries for the configuration entry targeted by this `.config` file. This is caused by a known bug. See `LPS-76352 <https://issues.liferay.com/browse/LPS-76352>`_ for more information. Once an improperly named configuration file is deployed, you can't add any entries for the configuration in question from its System Settings entry.


### PR DESCRIPTION
… a subname.

@achaparro - Would you review this change? Thanks!